### PR TITLE
Convert endpoints to use Markdown instead of JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	maragu.dev/errors v0.3.0
 	maragu.dev/gai v0.0.0-20250313123402-8c9a025c3287
 	maragu.dev/gai-openai v0.0.0-20250311111057-ade511297a93
-	maragu.dev/httph v0.3.5
+	maragu.dev/httph v0.3.6
 	maragu.dev/is v0.2.0
 	maragu.dev/sqlh v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ maragu.dev/gai v0.0.0-20250313123402-8c9a025c3287 h1:idTIF2ceGFQnvEns78yrte1pm+l
 maragu.dev/gai v0.0.0-20250313123402-8c9a025c3287/go.mod h1:XikBR/X5krDNXqgd0Ncaggwmh89fyaURn5M1xAaKKaI=
 maragu.dev/gai-openai v0.0.0-20250311111057-ade511297a93 h1:GUw2+8O223cWwGtc4djxYgrk1OR+pMucMve0o/0cj3U=
 maragu.dev/gai-openai v0.0.0-20250311111057-ade511297a93/go.mod h1:pEQZkn+yxYLAY1zvorKE48wTVegdylbfewRJVmTQEoA=
-maragu.dev/httph v0.3.5 h1:g0ebwFA8Hv+UOoJNcYdHy9gqPLWHTf2kHXEq3Gma3Ac=
-maragu.dev/httph v0.3.5/go.mod h1:DGE2xtKBbL/ukcCGK/IvmUA1ni6ylusjWBgAMkCvTnc=
+maragu.dev/httph v0.3.6 h1:VDvph5AV/WXY1OXUDcbGTTTCgPiDvXqVDCeFT9TZBWU=
+maragu.dev/httph v0.3.6/go.mod h1:DGE2xtKBbL/ukcCGK/IvmUA1ni6ylusjWBgAMkCvTnc=
 maragu.dev/is v0.2.0 h1:poeuVEA5GG3vrDpGmzo2KjWtIMZmqUyvGnOB0/pemig=
 maragu.dev/is v0.2.0/go.mod h1:bviaM5S0fBshCw7wuumFGTju/izopZ/Yvq4g7Klc7y8=
 maragu.dev/migrate v0.6.0 h1:gJLAIVaRh9z9sN55Q2sWwScpEH+JsT6N0L1DnzedXFE=

--- a/http/documents.go
+++ b/http/documents.go
@@ -56,7 +56,7 @@ func Documents(mux chi.Router, db documentCRUDer, ai embedder) {
 		}
 
 		for _, doc := range docs {
-			w.Write([]byte("- [" + doc.ID + "](/documents/" + doc.ID + ")\n"))
+			_, _ = w.Write([]byte("- [" + doc.ID + "](/documents/" + doc.ID + ")\n"))
 		}
 
 		return nil
@@ -76,7 +76,7 @@ func Documents(mux chi.Router, db documentCRUDer, ai embedder) {
 			return errors.Wrap(err, "error getting document")
 		}
 
-		w.Write([]byte(doc.Content))
+		_, _ = w.Write([]byte(doc.Content))
 
 		return nil
 	}))
@@ -99,8 +99,7 @@ func Documents(mux chi.Router, db documentCRUDer, ai embedder) {
 			return errors.Wrap(err, "error creating document chunks")
 		}
 
-		doc, err = db.UpdateDocument(r.Context(), doc, chunks)
-		if err != nil {
+		if _, err = db.UpdateDocument(r.Context(), doc, chunks); err != nil {
 			if errors.Is(err, model.ErrorDocumentNotFound) {
 				return httph.HTTPError{
 					Code: http.StatusNotFound,
@@ -110,7 +109,7 @@ func Documents(mux chi.Router, db documentCRUDer, ai embedder) {
 			return errors.Wrap(err, "error updating document")
 		}
 
-		w.Write(body)
+		_, _ = w.Write(body)
 
 		return nil
 	}))

--- a/http/routes.go
+++ b/http/routes.go
@@ -12,7 +12,7 @@ func (s *Server) setupRoutes() {
 		r.Use(middleware.RealIP)
 
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.SetHeader("Content-Type", "application/json"))
+			r.Use(middleware.SetHeader("Content-Type", "text/markdown"))
 
 			Documents(r, s.db, s.ai)
 			Search(r, s.db, s.ai)

--- a/http/search.go
+++ b/http/search.go
@@ -28,7 +28,7 @@ func Search(mux chi.Router, db searcher, ai embedder) {
 		}
 
 		for _, chunk := range chunks {
-			w.Write([]byte("- [" + chunk.Content + "](/documents/" + string(chunk.ID) + ")\n"))
+			_, _ = w.Write([]byte("- [" + chunk.Content + "](/documents/" + string(chunk.ID) + ")\n"))
 		}
 
 		return nil

--- a/http/search_test.go
+++ b/http/search_test.go
@@ -1,0 +1,49 @@
+package http_test
+
+import (
+	"context"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"maragu.dev/is"
+
+	"app/aitest"
+	"app/http"
+	"app/model"
+	"app/sqltest"
+)
+
+func TestSearch(t *testing.T) {
+	t.Run("search documents", func(t *testing.T) {
+		db := sqltest.NewDatabase(t)
+		ai := aitest.NewClient(t)
+		mux := chi.NewRouter()
+		http.Search(mux, db, ai)
+
+		// Create document with content and chunks
+		doc := model.Document{Content: "This is a test document with searchable content"}
+		chunks, err := doc.Chunk(context.Background(), ai.EmbedString)
+		is.NotError(t, err)
+		
+		// Save document with chunks
+		_, err = db.CreateDocument(t.Context(), doc, chunks)
+		is.NotError(t, err)
+
+		// Now search for content
+		req := httptest.NewRequest("GET", "/search?q=searchable", nil)
+		w := httptest.NewRecorder()
+
+		mux.ServeHTTP(w, req)
+
+		is.Equal(t, stdhttp.StatusOK, w.Code)
+		
+		// The response should contain markdown links to the documents
+		responseBody := w.Body.String()
+		is.True(t, len(responseBody) > 0)
+		is.True(t, strings.Contains(responseBody, "- ["))
+		is.True(t, strings.Contains(responseBody, "](/documents/"))
+	})
+}


### PR DESCRIPTION
- Changed all endpoints to use Markdown instead of JSON for request and response bodies
- Updated tests to reflect the new format
- Added search_test.go to test the search endpoint